### PR TITLE
Check for invalid patterns in `net.ClientSPICE().fetch()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermpy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tools for space science at Mercury"
 keywords = ["hermpy", "mercury", "space", "science", "messenger", "bepicolombo"]
 

--- a/src/hermpy/net/client_spice.py
+++ b/src/hermpy/net/client_spice.py
@@ -91,8 +91,14 @@ def expand_patterns(base_url: str, directory: str, patterns: list[str]) -> list[
 
     matched = []
     for pattern in patterns:
-        matched.extend(
-            f"{full_dir_url}{fname}" for fname in files if fnmatch(fname, pattern)
-        )
+        # Check first if file exists
+        hits = [f"{full_dir_url}{fname}" for fname in files if fnmatch(fname, pattern)]
+
+        if not hits:
+            raise FileNotFoundError(
+                f"No remote files matched pattern '{pattern}' in {full_dir_url}"
+            )
+
+        matched.extend(hits)
 
     return matched

--- a/src/hermpy/net/client_spice.py
+++ b/src/hermpy/net/client_spice.py
@@ -23,6 +23,11 @@ class ClientSPICE:
                 "DIRECTORY": "generic_kernels/pck/",
                 "PATTERNS": ["pck00011.tpc"],
             },
+            "Generic (bsp)": {  # Planets
+                "BASE": "https://naif.jpl.nasa.gov/pub/naif/",
+                "DIRECTORY": "generic_kernels/spk/planets/",
+                "PATTERNS": ["de442.bsp"],
+            },
         },
     ):
         self.KERNEL_LOCATIONS = KERNEL_LOCATIONS

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "hermpy"
-version = "0.1.2"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
Adds a check for invalid patterns in `net.ClientSPICE().fetch()`.

Raises FileNotFoundError with descriptive text for which kernel patterns are failing.

This means that missing kernels will not fail silently.