### PR TITLE
Fixes issues with FIPS spectrogram plotting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+import tomllib
+from pathlib import Path
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -9,7 +12,10 @@
 project = "hermpy"
 copyright = "2026, Daragh M. Hollman"
 author = "Daragh M. Hollman"
-release = "0.2.3"
+
+# Set release based on pyproject.toml
+with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as f:
+    release = tomllib.load(f)["project"]["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/sg_execution_times.rst
+++ b/docs/sg_execution_times.rst
@@ -6,7 +6,7 @@
 
 Computation times
 =================
-**00:09.240** total execution time for 4 files **from all galleries**:
+**00:15.307** total execution time for 4 files **from all galleries**:
 
 .. container::
 
@@ -32,13 +32,13 @@ Computation times
    * - Example
      - Time
      - Mem (MB)
-   * - :ref:`sphx_glr_generated_examples_mercury-schematic.py` (``../src/examples/mercury-schematic.py``)
-     - 00:09.240
+   * - :ref:`sphx_glr_generated_examples_multipanel_plots.py` (``../src/examples/multipanel_plots.py``)
+     - 00:15.307
      - 0.0
    * - :ref:`sphx_glr_generated_examples_download_data.py` (``../src/examples/download_data.py``)
      - 00:00.000
      - 0.0
-   * - :ref:`sphx_glr_generated_examples_multipanel_plots.py` (``../src/examples/multipanel_plots.py``)
+   * - :ref:`sphx_glr_generated_examples_mercury-schematic.py` (``../src/examples/mercury-schematic.py``)
      - 00:00.000
      - 0.0
    * - :ref:`sphx_glr_generated_examples_spice.py` (``../src/examples/spice.py``)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermpy"
-version = "0.2.3"
+version = "0.2.4"
 description = "Tools for space science at Mercury"
 keywords = ["hermpy", "mercury", "space", "science", "messenger", "bepicolombo"]
 

--- a/src/examples/multipanel_plots.py
+++ b/src/examples/multipanel_plots.py
@@ -12,7 +12,7 @@ import xarray as xr
 from astropy.table import QTable
 from sunpy.time import TimeRange
 
-from hermpy.data import parse_messenger_fips, parse_messenger_mag
+from hermpy.data import fips_energy_bin_edges, parse_messenger_fips, parse_messenger_mag
 from hermpy.net import ClientMESSENGER
 from hermpy.plotting import MultiPanel, SpectrogramPanel, TimeseriesPanel
 
@@ -25,7 +25,7 @@ from hermpy.plotting import MultiPanel, SpectrogramPanel, TimeseriesPanel
 #
 # .. _here: download_data.html
 c = ClientMESSENGER()
-time_range = TimeRange("2011-06-01T00:00", "2011-06-01T01:00")
+time_range = TimeRange("2011-09-26T12:00", "2011-09-26T13:20")
 
 c.query(time_range, "MAG")
 mag_file_paths = c.fetch()
@@ -72,14 +72,26 @@ fig, ax = mag_panel.plot()
 # %%
 # Plotting with more than one panel
 # ---------------------------------
-# However, the power in Panel objects comes when we go to construct multipanel
-# plots. We can combine Panel objects to construct a multi-panel plot by simply
-# adding them.
+# The power in Panel objects comes when we go to construct multipanel plots. We
+# can combine Panel objects to construct a multi-panel plot by simply adding
+# them.
 #
 # Lets make a second panel where we plot the FIPS data. We can combine the two
-# using the addition operator.
+# using the addition operator. ``SpectrogramPanel`` doesn't know anything about
+# our data, so we need to provide the time axis, y axis, and y bin edges.
 proton_flux = fips_data["Proton Flux"]
-fips_panel = SpectrogramPanel(proton_flux)
+fips_panel = SpectrogramPanel(
+    proton_flux,
+    time_dim="UTC",
+    y_dim="Energy Channel",
+    y_bin_edges=fips_energy_bin_edges(),
+    cmap="magma",
+    unit="DEF [e / cm$^2$ s sr keV]",
+)
+
+# %%
+# We can set anything about the plot with ``ax_set_params``
+fips_panel.ax_set_params = {"ylabel": "E/q [keV/e]"}
 
 multipanel: MultiPanel = mag_panel + fips_panel
 fig, axes = multipanel.plot()

--- a/src/hermpy/plotting/panels.py
+++ b/src/hermpy/plotting/panels.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
@@ -42,6 +43,8 @@ class MultiPanel:
         for panel, ax in zip(self._panels, axes):
             panel._plot_on(ax)
 
+            ax.set(**panel.ax_set_params)
+
         if show:
             plt.show()
 
@@ -53,6 +56,7 @@ class Panel(ABC):
 
     def __init__(self, time_column: str = "UTC"):
         self.time_column = time_column
+        self._ax_set_params: dict = {}
 
     def __add__(self, other) -> MultiPanel:
         # If other is another Panel, we can just pass this Panel and the
@@ -73,13 +77,25 @@ class Panel(ABC):
     @abstractmethod
     def _plot_on(self, ax):
         """Plot panel content on the given axis."""
-        pass
+        ...
+
+    @property
+    def ax_set_params(self) -> dict:
+        return self._ax_set_params
+
+    @ax_set_params.setter
+    def ax_set_params(self, params: dict):
+        if not isinstance(params, dict):
+            raise TypeError(f"`ax_set_params` must be a dict, got {type(params)}")
+        self._ax_set_params = params
 
     def plot(self, show=True):
         """Creates a quick plot for this panel alone."""
 
         fig, ax = plt.subplots()
         self._plot_on(ax)
+
+        ax.set(**self.ax_set_params)
 
         if show:
             plt.show()
@@ -94,7 +110,7 @@ class TimeseriesPanel(Panel):
         self._check_units()
 
     @property
-    def unit(self):
+    def unit(self) -> u.Unit:
         return self._unit
 
     def _check_units(self):
@@ -145,22 +161,26 @@ class SpectrogramPanel(Panel):
     def __init__(
         self,
         data: xr.DataArray,
-        time_dim: str = "UTC",
-        y_dim: str = "Energy Channel",
+        time_dim: str,
+        y_dim: str,
         y_bin_edges: list[float | int] | None = None,
+        yscale="log",
         vmin=None,
         vmax=None,
         cmap="viridis",
-        yscale="log",
+        cmap_scale="log",
+        unit="",
     ):
         self.data = data
         self.time_dim = time_dim
         self.y_dim = y_dim
         self.y_bin_edges = y_bin_edges or np.arange(0, len(data[y_dim]) + 1).tolist()
+        self.yscale = yscale
         self.vmin = vmin
         self.vmax = vmax
         self.cmap = cmap
-        self.yscale = yscale
+        self.cmap_scale = cmap_scale
+        self.unit = unit
 
     def _plot_on(self, ax):
         mesh = ax.pcolormesh(
@@ -171,11 +191,12 @@ class SpectrogramPanel(Panel):
             vmin=self.vmin,
             vmax=self.vmax,
             cmap=self.cmap,
+            norm=self.cmap_scale,
         )
 
         cbar_bounds = (1.02, 0, 0.02, 1)
         self.cbar_ax = ax.inset_axes(cbar_bounds)
 
-        self.cbar = plt.colorbar(mesh, cax=self.cbar_ax)
+        self.cbar = plt.colorbar(mesh, cax=self.cbar_ax, label=self.unit)
 
         ax.set_yscale(self.yscale)

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "hermpy"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
Adds to `hermpy.plotting.Panel` and `.SpectrogramPanel` to let users access `ax.set()` on a panel level.

Fixes FIPS plotting example to use calibrated bin edges

Adds axis labels to FIPS panel in [multipanel_plots example
](https://hermpy.readthedocs.io/en/stable/generated_examples/multipanel_plots.html)( Fixes #10 )